### PR TITLE
Fix beta mods

### DIFF
--- a/NoodleManagerX/Mods/ModHandler.cs
+++ b/NoodleManagerX/Mods/ModHandler.cs
@@ -23,7 +23,9 @@ namespace NoodleManagerX.Mods
     class ModHandler : GenericHandler
     {
         public override ItemType itemType { get; set; } = ItemType.Mod;
-        public override string apiEndpoint { get; set; } = ModDownloadSource.GetModsBaseUrl();
+
+        // Note - this is required to override, but to get the url based on the beta flag it is directly accessed later
+        public override string apiEndpoint { get; set; } = "";
         public override string folder { get; set; } = "Mods";
         public override string[] extensions { get; set; } = { ".synthmod" };
 
@@ -237,7 +239,8 @@ namespace NoodleManagerX.Mods
             {
                 using (HttpClient client = new HttpClient())
                 {
-                    string requestUrl = apiEndpoint + "/mods.json";
+                    string requestUrl = ModDownloadSource.GetModsBaseUrl() + "/mods.json";
+                    MainViewModel.Log($"Getting mod list from {requestUrl}");
                     string rawResponse = await client.GetStringAsync(requestUrl);
                     if (MainViewModel.s_instance.apiRequestCounter != requestID)
                     {

--- a/NoodleManagerX/Mods/ModItem.cs
+++ b/NoodleManagerX/Mods/ModItem.cs
@@ -26,7 +26,6 @@ namespace NoodleManagerX.Mods
     [DataContract]
     class ModItem : GenericItem
     {
-        public static string baseDownloadUrl = ModDownloadSource.GetModItemBaseDownloadUrl();
         public override string target { get; set; } = "Mods";
         public override ItemType itemType { get; set; } = ItemType.Mod;
 
@@ -131,7 +130,7 @@ namespace NoodleManagerX.Mods
 
             try
             {
-                string url = baseDownloadUrl + "/" + modVersion.DownloadUrl;
+                string url = ModDownloadSource.GetModItemBaseDownloadUrl() + "/" + modVersion.DownloadUrl;
                 MainViewModel.Log($"Downloading from {url}");
 
                 using HttpClient client = new HttpClient();


### PR DESCRIPTION
Forgot about these changes, and tested them a bit more. Now able to switch back and forth between beta and non-beta mod lists and the updates/reversions seem to be working as expected for SRPlaylistManager.

I'm planning to update the mod lists soon - there's a couple mod updates and a new mod to add in. I'm also thinking about abstracting this out a bit after looking at https://github.com/Contiinuum/ModBrowser/tree/main (Audica mod browsing). Pointing to github repos and being able to partially generate the dependency list based on tags would be nice and easier to maintain/keep updated, although it would prevent any checking of mod versions/compatibility before adding in. Thoughts?