### PR TITLE
Fix path to downloaded mods

### DIFF
--- a/NoodleManagerX/Mods/ModItem.cs
+++ b/NoodleManagerX/Mods/ModItem.cs
@@ -204,11 +204,14 @@ namespace NoodleManagerX.Mods
                         {
                             if (entry.FullName != "LocalItem.json")
                             {
-                                if (StorageAbstraction.FileExists(entry.FullName))
+                                // The synth dir is the SynthRidersUC directory. We need to extract up a level.
+                                var entryRelPath = Path.Combine("..", entry.FullName);
+                                
+                                if (StorageAbstraction.FileExists(entryRelPath))
                                 {
-                                    MainViewModel.Log($"WARNING: Overwriting {entry.FullName}");
+                                    MainViewModel.Log($"WARNING: Overwriting {entryRelPath}");
                                     // TODO use a more generic function once modding is supported on Oculus
-                                    var fullPath = StorageAbstraction.GetFullComputerPath(entry.FullName);
+                                    var fullPath = StorageAbstraction.GetFullComputerPath(entryRelPath);
                                     entry.ExtractToFile(fullPath, true);
                                 }
                                 else
@@ -216,14 +219,14 @@ namespace NoodleManagerX.Mods
                                     if (String.IsNullOrEmpty(entry.Name))
                                     {
                                         // No file name, so directory
-                                        MainViewModel.Log($"Creating directory for {entry.FullName}");
-                                        await StorageAbstraction.CreateDirectory(entry.FullName);
+                                        MainViewModel.Log($"Creating directory for {entryRelPath}");
+                                        await StorageAbstraction.CreateDirectory(entryRelPath);
                                     }
                                     else
                                     {
-                                        MainViewModel.Log($"Extracting file {entry.FullName}");
+                                        MainViewModel.Log($"Extracting file {entryRelPath}");
                                         // TODO use a more generic function once modding is supported on Oculus
-                                        var fullPath = StorageAbstraction.GetFullComputerPath(entry.FullName);
+                                        var fullPath = StorageAbstraction.GetFullComputerPath(entryRelPath);
                                         entry.ExtractToFile(fullPath);
                                     }
                                 }

--- a/NoodleManagerX/Mods/ModItem.cs
+++ b/NoodleManagerX/Mods/ModItem.cs
@@ -264,8 +264,9 @@ namespace NoodleManagerX.Mods
                             {
                                 if (entry.FullName != "LocalItem.json")
                                 {
-                                    var fullPath = Path.Combine(MainViewModel.s_instance.settings.synthDirectory, entry.FullName);
-                                    if (StorageAbstraction.FileExists(entry.FullName))
+                                    var parentFileName = Path.Combine("..", entry.FullName);
+                                    var fullPath = Path.Combine(MainViewModel.s_instance.settings.synthDirectory, parentFileName);
+                                    if (StorageAbstraction.FileExists(parentFileName))
                                     {
                                         MainViewModel.Log("Deleting " + fullPath);
                                         StorageAbstraction.DeleteFile(fullPath);


### PR DESCRIPTION
The path used for downloading and checking mods was not in the right place, since the base synth riders dir now points to SynthRidersUC. Thanks to Chipdancer for pointing this out!